### PR TITLE
Added ability to use the parent's offset in order to calculated whether element was stuck

### DIFF
--- a/src/ng-sticky.directive.ts
+++ b/src/ng-sticky.directive.ts
@@ -1,53 +1,58 @@
-import { Directive, ElementRef, Input, HostListener, Renderer2 } from '@angular/core';
+import {Directive, ElementRef, Input, HostListener, Renderer2} from "@angular/core";
 
 @Directive({
-  selector: '[ng-sticky]'
+    selector: "[ng-sticky]"
 })
 export class NgStickyDirective {
 
-  private sticked: boolean = true;
-  private selectedOffset: number = 0;
-  private windowOffsetTop: number = 0;
+    private sticked: boolean = true;
+    private selectedOffset: number = 0;
+    private windowOffsetTop: number = 0;
 
-  @Input() addClass: string = 'fixed';
-  @Input() offSet: number = 0;
+    @Input() addClass: string = "fixed";
+    @Input() offSet: number = 0;
+    @Input() getOffsetTopFromParent = false;
 
-  constructor(private el: ElementRef, private render:Renderer2) {
-    this.selectedOffset = this.el.nativeElement.offsetTop;
-  }
+    constructor(private el: ElementRef, private render: Renderer2) {
+        this.selectedOffset = this.el.nativeElement.offsetTop;
+    }
 
-  private addSticky() {
-    this.sticked = true;
-    this.el.nativeElement.style.position = 'fixed';
-    this.el.nativeElement.style.top = this.offSet + 'px';
-    this.render.addClass(this.el.nativeElement, this.addClass);
-  }
+    private addSticky() {
+        this.sticked = true;
+        this.el.nativeElement.style.position = "fixed";
+        this.el.nativeElement.style.top = this.offSet + "px";
+        this.render.addClass(this.el.nativeElement, this.addClass);
+    }
 
-  private removeSticky() {
-    this.sticked = false;
-    this.el.nativeElement.style.position = '';
-    this.render.removeClass(this.el.nativeElement, this.addClass);
-  }
+    private removeSticky() {
+        this.sticked = false;
+        this.el.nativeElement.style.position = "";
+        this.render.removeClass(this.el.nativeElement, this.addClass);
+    }
 
-  @HostListener("window:scroll", [])
+    private offsetIsDerivedFromParent() {
+        return this.getOffsetTopFromParent && this.el.nativeElement.offsetParent;
+    }
+
+    @HostListener("window:scroll", [])
     onWindowScroll() {
 
-      let offset: number = this.el.nativeElement.offsetTop;
-      this.windowOffsetTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+        const offset = this.offsetIsDerivedFromParent() ? this.el.nativeElement.offsetParent.offsetTop : this.el.nativeElement.offsetTop;
+        this.windowOffsetTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
 
-      if (this.selectedOffset === 0) {
-        this.selectedOffset = offset;
-      }
+        if (this.selectedOffset === 0) {
+            this.selectedOffset = offset;
+        }
 
-      if (this.sticked === false) {
-        this.selectedOffset = offset;
-      }
+        if (this.sticked === false) {
+            this.selectedOffset = offset;
+        }
 
-      if ((this.windowOffsetTop + this.offSet) > this.selectedOffset) {
-        
-        this.addSticky();
-      } else {
-        this.removeSticky();
-      }
+        if ((this.windowOffsetTop + this.offSet) > this.selectedOffset) {
+
+            this.addSticky();
+        } else {
+            this.removeSticky();
+        }
     }
 }

--- a/src/ng-sticky.directive.ts
+++ b/src/ng-sticky.directive.ts
@@ -1,16 +1,16 @@
-import {Directive, ElementRef, Input, HostListener, Renderer2} from "@angular/core";
+import {Directive, ElementRef, Input, HostListener, Renderer2} from '@angular/core';
 
 @Directive({
-    selector: "[ng-sticky]"
+    selector: '[ng-sticky]'
 })
 export class NgStickyDirective {
 
-    private sticked: boolean = true;
-    private selectedOffset: number = 0;
-    private windowOffsetTop: number = 0;
+    private stuck = true;
+    private selectedOffset = 0;
+    private windowOffsetTop = 0;
 
-    @Input() addClass: string = "fixed";
-    @Input() offSet: number = 0;
+    @Input() addClass = 'fixed';
+    @Input() offSet = 0;
     @Input() getOffsetTopFromParent = false;
 
     constructor(private el: ElementRef, private render: Renderer2) {
@@ -18,15 +18,15 @@ export class NgStickyDirective {
     }
 
     private addSticky() {
-        this.sticked = true;
-        this.el.nativeElement.style.position = "fixed";
-        this.el.nativeElement.style.top = this.offSet + "px";
+        this.stuck = true;
+        this.el.nativeElement.style.position = 'fixed';
+        this.el.nativeElement.style.top = this.offSet + 'px';
         this.render.addClass(this.el.nativeElement, this.addClass);
     }
 
     private removeSticky() {
-        this.sticked = false;
-        this.el.nativeElement.style.position = "";
+        this.stuck = false;
+        this.el.nativeElement.style.position = '';
         this.render.removeClass(this.el.nativeElement, this.addClass);
     }
 
@@ -36,20 +36,15 @@ export class NgStickyDirective {
 
     @HostListener("window:scroll", [])
     onWindowScroll() {
-
         const offset = this.offsetIsDerivedFromParent() ? this.el.nativeElement.offsetParent.offsetTop : this.el.nativeElement.offsetTop;
+
         this.windowOffsetTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
 
-        if (this.selectedOffset === 0) {
-            this.selectedOffset = offset;
-        }
+        if (this.selectedOffset === 0) this.selectedOffset = offset;
 
-        if (this.sticked === false) {
-            this.selectedOffset = offset;
-        }
+        if (this.stuck === false) this.selectedOffset = offset;
 
         if ((this.windowOffsetTop + this.offSet) > this.selectedOffset) {
-
             this.addSticky();
         } else {
             this.removeSticky();


### PR DESCRIPTION
In our use case we had a container element which had a few children. One of those children was supposed to stick because it was the most important of the features. I added an input to specify whether you want to use the element's offset or the element's parent's offset when calculating whether the element should be stuck or not.