### PR TITLE
Elements with position: absolute & top properties are positioned incorrectly on sticky deactivation

### DIFF
--- a/src/ng-sticky.directive.ts
+++ b/src/ng-sticky.directive.ts
@@ -25,7 +25,7 @@ export class NgStickyDirective {
 
   private removeSticky() {
     this.sticked = false;
-    this.el.nativeElement.style.position = '';
+    this.render.setAttribute(this.el.nativeElement, 'style', null);
     this.render.removeClass(this.el.nativeElement, this.addClass);
   }
 
@@ -44,7 +44,6 @@ export class NgStickyDirective {
       }
 
       if ((this.windowOffsetTop + this.offSet) > this.selectedOffset) {
-        
         this.addSticky();
       } else {
         this.removeSticky();


### PR DESCRIPTION
Elements with CSS property `position` set to `absolute` are incorrectly positioned after ng-sticky gets deactivated if `top` attribute is different than `0`. 
This is due to the fact that `removeSticky()` method leaves `top` property active on previously stickied element (only `position` property gets removed on deactivation - `this.el.nativeElement.style.position = '';`).

Example:
Element which holds ng-sticky directive has the following CSS:
```
position: absolute;
top: 30px;
```
After sticky deactivation, `top` property stays active and is set to `0` which places the element in a wrong place.

This pull request solves the problem by removing the whole `style` attribute upon sticky deactivation.